### PR TITLE
fix: normalize OpenAI Compatible baseURL to avoid 404 on listModels

### DIFF
--- a/src/providers/OpenAICompatibleProvider.ts
+++ b/src/providers/OpenAICompatibleProvider.ts
@@ -12,6 +12,9 @@ export class OpenAICompatibleProvider extends BaseProvider {
     },
   ) {
     super();
+    this.options.baseURL = this.options.baseURL.endsWith("/")
+      ? this.options.baseURL
+      : this.options.baseURL + "/";
   }
 
   get providerId(): AvailableProviders {
@@ -28,7 +31,7 @@ export class OpenAICompatibleProvider extends BaseProvider {
   }
 
   async listModels(): Promise<ModelInfo[]> {
-    const url = new URL("./models", this.options.baseURL);
+    const url = new URL("models", this.options.baseURL);
 
     const res = await fetch(url.toString(), {
       headers: this.buildFetchHeaders(),


### PR DESCRIPTION
## Summary
- When the user-provided OpenAI Compatible baseURL lacked a trailing slash (e.g. `https://api.example.com/v1`), `new URL("./models", baseURL)` resolved to `https://api.example.com/models` — dropping the `/v1` segment — and `listModels` returned 404.
- Normalize `baseURL` in the constructor to always end with `/`, and drop the now-redundant `./` prefix on the relative path.

## Test plan
- [ ] Configure an OpenAI Compatible provider with a baseURL ending in `/v1` (no trailing slash) and verify model listing succeeds.
- [ ] Repeat with a baseURL ending in `/v1/` and verify it still works.
- [ ] Send a chat request with each form to confirm `getModel` continues to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)