### PR TITLE
Fix DeepSeek V4 reasoning content pass-through

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@ai-sdk/anthropic": "^3.0.9",
+    "@ai-sdk/deepseek": "^2.0.35",
     "@ai-sdk/google": "^3.0.6",
     "@ai-sdk/openai": "^3.0.8",
     "@ai-sdk/openai-compatible": "^2.0.4",

--- a/src/components/ApiKeyForm.vue
+++ b/src/components/ApiKeyForm.vue
@@ -82,6 +82,24 @@
         <template #label>Custom Headers</template>
       </BaseInput>
     </template>
+    <template v-if="selectedProvider === 'deepseek'">
+      <BaseInput v-model="deepseekBaseUrl">
+        <template #label>Base URL</template>
+        <template #helper>DeepSeek API base URL.</template>
+      </BaseInput>
+      <BaseInput v-model="deepseekApiKey" type="password">
+        <template #label>API Key</template>
+        <template #helper>
+          Get your
+          <ExternalLink href="https://platform.deepseek.com/api_keys">
+            API Key here.
+          </ExternalLink>
+        </template>
+      </BaseInput>
+      <BaseInput v-model="deepseekHeaders" type="textarea">
+        <template #label>Custom Headers</template>
+      </BaseInput>
+    </template>
     <template v-if="selectedProvider === 'ollama'">
       <BaseInput v-model="ollamaBaseUrl">
         <template #label>Ollama Base URL</template>
@@ -124,6 +142,9 @@ export default {
       googleApiKey: config["providers.google.apiKey"],
       ollamaBaseUrl: config.providers_ollama_baseUrl,
       ollamaHeaders: config.providers_ollama_headers,
+      deepseekBaseUrl: config.providers_deepseek_baseUrl,
+      deepseekApiKey: config.providers_deepseek_apiKey,
+      deepseekHeaders: config.providers_deepseek_headers,
       openaiCompatBaseUrl: config.providers_openaiCompat_baseUrl,
       openaiCompatApiKey: config.providers_openaiCompat_apiKey,
       openaiCompatHeaders: config.providers_openaiCompat_headers,
@@ -161,6 +182,18 @@ export default {
     },
     ollamaHeaders() {
       this.configure("providers_ollama_headers", this.ollamaHeaders);
+      this.$emit("change");
+    },
+    deepseekBaseUrl() {
+      this.configure("providers_deepseek_baseUrl", this.deepseekBaseUrl);
+      this.$emit("change");
+    },
+    deepseekApiKey() {
+      this.configure("providers_deepseek_apiKey", this.deepseekApiKey);
+      this.$emit("change");
+    },
+    deepseekHeaders() {
+      this.configure("providers_deepseek_headers", this.deepseekHeaders);
       this.$emit("change");
     },
     openaiCompatBaseUrl() {

--- a/src/components/configuration/ProvidersConfiguration.vue
+++ b/src/components/configuration/ProvidersConfiguration.vue
@@ -6,6 +6,43 @@
   </form>
 
   <form @submit.prevent class="config-form">
+    <h3>DeepSeek</h3>
+    <p class="description">Connect to DeepSeek with first-party AI SDK support.</p>
+    <div
+      v-for="(error, index) in deepseekErrors"
+      :key="index"
+      class="alert alert-danger"
+    >
+      <span class="material-symbols-outlined">error_outline</span>
+      <span>{{ error }}</span>
+    </div>
+    <BaseInput
+      :model-value="providers_deepseek_baseUrl"
+      @update:modelValue="configure('providers_deepseek_baseUrl', $event)"
+      @change="handleChange($event, 'deepseek')"
+    >
+      <template #label>URL</template>
+      <template #helper>DeepSeek API base URL.</template>
+    </BaseInput>
+    <BaseInput
+      type="password"
+      :model-value="providers_deepseek_apiKey"
+      @update:modelValue="configure('providers_deepseek_apiKey', $event)"
+      @change="handleChange($event, 'deepseek')"
+    >
+      <template #label>API Key</template>
+    </BaseInput>
+    <BaseInput
+      type="textarea"
+      :model-value="providers_deepseek_headers"
+      @update:modelValue="configure('providers_deepseek_headers', $event)"
+      @change="handleChange($event, 'deepseek')"
+    >
+      <template #label>Headers</template>
+    </BaseInput>
+  </form>
+
+  <form @submit.prevent class="config-form">
     <h3>OpenAI Compatible</h3>
     <p class="description">Connect to any service using OpenAI's API format.</p>
     <div
@@ -101,6 +138,9 @@ export default {
 
   computed: {
     ...mapState(useConfigurationStore, [
+      "providers_deepseek_baseUrl",
+      "providers_deepseek_apiKey",
+      "providers_deepseek_headers",
       "providers_openaiCompat_baseUrl",
       "providers_openaiCompat_apiKey",
       "providers_openaiCompat_headers",
@@ -108,6 +148,14 @@ export default {
       "providers_ollama_headers",
     ]),
     ...mapState(useChatStore, ["errors"]),
+    deepseekErrors() {
+      return this.errors
+        .filter(
+          (error) =>
+            error.providerId === "deepseek" && !error.message.includes("[2]"),
+        )
+        .map((error) => error.message);
+    },
     openAiCompatibleErrors() {
       return this.errors
         .filter(

--- a/src/composables/ai.ts
+++ b/src/composables/ai.ts
@@ -377,7 +377,7 @@ class AIShellChat {
     }
     const model = this.getModelOrThrow();
     let prompt =
-      "Name this conversation in less than 30 characters or 6 words.\n```";
+      "Name this conversation in less than 30 characters or 6 words. Return JSON only.\n```";
     this.messages.value.forEach((m) => {
       m.parts.forEach((p) => {
         if (p.type === "text") {

--- a/src/config.ts
+++ b/src/config.ts
@@ -241,6 +241,12 @@ export const providerConfigs = {
     ],
     supportsRuntimeModels: false,
   },
+  deepseek: {
+    displayName: "DeepSeek",
+    models: [],
+    /** Models are fetched at runtime */
+    supportsRuntimeModels: true,
+  },
   openaiCompat: {
     displayName: "OpenAI-Compatible",
     models: [],

--- a/src/providers/DeepSeekProvider.ts
+++ b/src/providers/DeepSeekProvider.ts
@@ -1,0 +1,89 @@
+import type { AvailableProviders, ModelInfo } from "@/config";
+import { BaseProvider } from "@/providers/BaseProvider";
+import { createDeepSeek } from "@ai-sdk/deepseek";
+
+const DEFAULT_BASE_URL = "https://api.deepseek.com";
+
+type DeepSeekModelsResponse = {
+  data?: {
+    id?: string;
+    name?: string;
+    context_length?: number;
+  }[];
+  error?: string | { message?: string };
+};
+
+export class DeepSeekProvider extends BaseProvider {
+  constructor(
+    protected options: {
+      baseURL?: string;
+      headers: Record<string, string>;
+      apiKey: string;
+    },
+  ) {
+    super();
+  }
+
+  get providerId(): AvailableProviders {
+    return "deepseek";
+  }
+
+  getModel(id: string) {
+    return createDeepSeek({
+      baseURL: this.baseURL,
+      apiKey: this.options.apiKey,
+      headers: this.options.headers,
+    }).languageModel(id);
+  }
+
+  async listModels(): Promise<ModelInfo[]> {
+    const url = new URL("./models", `${this.baseURL}/`);
+
+    const res = await fetch(url.toString(), {
+      headers: this.buildFetchHeaders(),
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to list models: ${res.statusText}`);
+    }
+
+    const data = (await res.json()) as DeepSeekModelsResponse;
+    if (data.error) {
+      throw new Error(`Failed to list models: ${this.errorMessage(data.error)}`);
+    }
+    if (!Array.isArray(data.data)) {
+      console.warn("Provider returns invalid data", this.baseURL, data);
+      return [];
+    }
+
+    try {
+      return data.data
+        .filter((m) => typeof m.id === "string")
+        .map<ModelInfo>((m) => ({
+          id: m.id!,
+          displayName: m.name ?? m.id!,
+          contextWindow: m.context_length,
+        }));
+    } catch (e) {
+      throw new Error(`Failed to list models: ${e}`);
+    }
+  }
+
+  protected buildFetchHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {};
+    if (this.options.apiKey) {
+      headers["Authorization"] = `Bearer ${this.options.apiKey}`;
+    }
+    return {
+      ...headers,
+      ...this.options.headers,
+    };
+  }
+
+  private get baseURL() {
+    return this.options.baseURL?.replace(/\/$/, "") || DEFAULT_BASE_URL;
+  }
+
+  private errorMessage(error: NonNullable<DeepSeekModelsResponse["error"]>) {
+    return typeof error === "string" ? error : error.message ?? "Unknown error";
+  }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,5 +1,6 @@
 import type { AvailableProviders } from "@/config";
 import { AnthropicProvider } from "@/providers/AnthropicProvider";
+import { DeepSeekProvider } from "@/providers/DeepSeekProvider";
 import { OpenAIProvider } from "@/providers/OpenAIProvider";
 import { OpenAICompatibleProvider } from "@/providers/OpenAICompatibleProvider";
 import { GoogleProvider } from "@/providers/GoogleProvider";
@@ -23,6 +24,18 @@ export function createProvider(id: AvailableProviders)  {
     case "google":
       return new GoogleProvider({
         apiKey: configuration["providers.google.apiKey"],
+      });
+    case "deepseek":
+      if (_.isEmpty(configuration.providers_deepseek_baseUrl)) {
+        throw new Error("Missing API base URL [2]");
+      }
+      if (_.isEmpty(configuration.providers_deepseek_apiKey)) {
+        throw new Error("Missing API key [2]");
+      }
+      return new DeepSeekProvider({
+        baseURL: configuration.providers_deepseek_baseUrl,
+        apiKey: configuration.providers_deepseek_apiKey,
+        headers: parseHeaders(configuration.providers_deepseek_headers),
       });
     case "openaiCompat":
       if (_.isEmpty(configuration.providers_openaiCompat_baseUrl)) {
@@ -50,4 +63,3 @@ export function createProvider(id: AvailableProviders)  {
       throw new Error(`Provider ${id} does not exist.`);
   }
 }
-

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -252,6 +252,9 @@ export const useChatStore = defineStore("chat", {
       internal.lastUsedModelId = this.model?.id;
 
       this.syncProvider("openaiCompat");
+      if (config.providers_deepseek_apiKey) {
+        this.syncProvider("deepseek");
+      }
       this.syncProvider("ollama");
       getDefaultInstructions()
         .then((instructions) => {

--- a/src/stores/configuration.ts
+++ b/src/stores/configuration.ts
@@ -45,6 +45,8 @@ type Configurable = {
   disabledModels: { providerId: AvailableProviders; modelId: string }[];
   /** Models that are removed are not shown in the UI and cannot be enabled. */
   removedModels: { providerId: AvailableProviders; modelId: string }[];
+  providers_deepseek_baseUrl: string;
+  providers_deepseek_headers: string;
   providers_openaiCompat_baseUrl: string;
   providers_openaiCompat_headers: string;
   providers_ollama_baseUrl: string;
@@ -58,6 +60,7 @@ type EncryptedConfigurable = {
   "providers.openai.apiKey": string;
   "providers.anthropic.apiKey": string;
   "providers.google.apiKey": string;
+  providers_deepseek_apiKey: string;
   providers_openaiCompat_apiKey: string;
 };
 
@@ -69,6 +72,7 @@ const encryptedConfigKeys: (keyof EncryptedConfigurable)[] = [
   "providers.openai.apiKey",
   "providers.anthropic.apiKey",
   "providers.google.apiKey",
+  "providers_deepseek_apiKey",
   "providers_openaiCompat_apiKey",
 ];
 
@@ -83,6 +87,9 @@ const defaultConfiguration: ConfigurationState = {
   "providers.openai.apiKey": "",
   "providers.anthropic.apiKey": "",
   "providers.google.apiKey": "",
+  providers_deepseek_baseUrl: "https://api.deepseek.com",
+  providers_deepseek_apiKey: "",
+  providers_deepseek_headers: "",
   providers_openaiCompat_baseUrl: "",
   providers_openaiCompat_apiKey: "",
   providers_openaiCompat_headers: "",
@@ -91,6 +98,7 @@ const defaultConfiguration: ConfigurationState = {
   providers_openai_models: [],
   providers_anthropic_models: [],
   providers_google_models: [],
+  providers_deepseek_models: [],
   providers_openaiCompat_models: [],
   providers_ollama_models: [],
   providers_mock_models: [],

--- a/tests/providers/DeepSeekProvider.spec.ts
+++ b/tests/providers/DeepSeekProvider.spec.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DeepSeekProvider } from "../../src/providers/DeepSeekProvider";
+
+describe("DeepSeekProvider", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("creates DeepSeek language models through the AI SDK provider", () => {
+    const provider = new DeepSeekProvider({
+      baseURL: "https://api.deepseek.com",
+      apiKey: "test-key",
+      headers: {},
+    });
+
+    const model = provider.getModel("deepseek-v4-flash");
+
+    expect(model.provider).toBe("deepseek.chat");
+    expect(model.modelId).toBe("deepseek-v4-flash");
+  });
+
+  it("lists models from the configured DeepSeek API", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            id: "deepseek-v4-flash",
+            name: "DeepSeek V4 Flash",
+            context_length: 128000,
+          },
+        ],
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = new DeepSeekProvider({
+      baseURL: "https://api.deepseek.com",
+      apiKey: "test-key",
+      headers: { "X-Test": "1" },
+    });
+
+    await expect(provider.listModels()).resolves.toEqual([
+      {
+        id: "deepseek-v4-flash",
+        displayName: "DeepSeek V4 Flash",
+        contextWindow: 128000,
+      },
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith("https://api.deepseek.com/models", {
+      headers: {
+        Authorization: "Bearer test-key",
+        "X-Test": "1",
+      },
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,14 @@
     "@ai-sdk/provider" "3.0.2"
     "@ai-sdk/provider-utils" "4.0.4"
 
+"@ai-sdk/deepseek@^2.0.35":
+  version "2.0.35"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/deepseek/-/deepseek-2.0.35.tgz#3644e0c13d9756328d658497844d4a73a1c30629"
+  integrity sha512-9DhYurbAvcurOEGN6u2myYDybrrzGfcrkG8hwmFjwTrePW6KCMggm0YxP7e8RkLYcQKqCEMgFlyEB4BM6EmiKg==
+  dependencies:
+    "@ai-sdk/provider" "3.0.10"
+    "@ai-sdk/provider-utils" "4.0.27"
+
 "@ai-sdk/gateway@3.0.11":
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/@ai-sdk/gateway/-/gateway-3.0.11.tgz#e34dd3e239f97b4ee0965407c3792eb06b9cbf2b"
@@ -43,6 +51,15 @@
     "@ai-sdk/provider" "3.0.2"
     "@ai-sdk/provider-utils" "4.0.4"
 
+"@ai-sdk/provider-utils@4.0.27":
+  version "4.0.27"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz#d2183685768626bcf1c968b7d73ea2b974da59b9"
+  integrity sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==
+  dependencies:
+    "@ai-sdk/provider" "3.0.10"
+    "@standard-schema/spec" "^1.1.0"
+    eventsource-parser "^3.0.8"
+
 "@ai-sdk/provider-utils@4.0.4":
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-4.0.4.tgz#b2f5af446f152be64124725677a900be615c8766"
@@ -65,6 +82,13 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-2.0.0.tgz#b853c739d523b33675bc74b6c506b2c690bc602b"
   integrity sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==
+  dependencies:
+    json-schema "^0.4.0"
+
+"@ai-sdk/provider@3.0.10":
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-3.0.10.tgz#abfb6776f699951f9b8ac20cf1d42a3fc7d79752"
+  integrity sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==
   dependencies:
     json-schema "^0.4.0"
 
@@ -1926,6 +1950,11 @@ eventsource-parser@^3.0.5, eventsource-parser@^3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.6.tgz#292e165e34cacbc936c3c92719ef326d4aeb4e90"
   integrity sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==
+
+eventsource-parser@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.8.tgz#1c792503e4080455d00701bb1f7a1d60734d0e58"
+  integrity sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==
 
 expect-type@^1.2.1:
   version "1.2.2"


### PR DESCRIPTION
## Summary

Fixes DeepSeek V4 thinking-mode follow-up calls by passing prior assistant reasoning back as `reasoning_content` for OpenAI-compatible DeepSeek V4 models.

- Preserve reasoning content on assistant history messages for DeepSeek V4 models
- Wrap OpenAI-compatible model calls so AI SDK internal tool-loop requests also receive `reasoning_content`
- Keep the behavior limited to `deepseek-v4*` model IDs instead of matching every DeepSeek-hosted model
- Add `JSON` to the generated-title prompt so DeepSeek accepts structured title generation

Related issue: beekeeper-studio/beekeeper-studio#4170

## Testing

- `corepack yarn test:run`
- `corepack yarn build`