### PR TITLE
Add DeepSeek provider via AI SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@ai-sdk/anthropic": "^3.0.9",
+    "@ai-sdk/deepseek": "^2.0.35",
     "@ai-sdk/google": "^3.0.6",
     "@ai-sdk/openai": "^3.0.8",
     "@ai-sdk/openai-compatible": "^2.0.4",

--- a/src/components/ApiKeyForm.vue
+++ b/src/components/ApiKeyForm.vue
@@ -67,6 +67,22 @@
         </ExternalLink>
       </template>
     </BaseInput>
+    <BaseInput
+      v-if="!dropdownBased || selectedProvider === 'deepseek'"
+      type="password"
+      placeholder="sk-..."
+      v-model="deepseekApiKey"
+    >
+      <template #label>
+        {{ dropdownBased ? "API Key" : providerConfigs["deepseek"].displayName }}
+      </template>
+      <template #helper>
+        Get your
+        <ExternalLink href="https://platform.deepseek.com/api_keys">
+          API Key here.
+        </ExternalLink>
+      </template>
+    </BaseInput>
     <template v-if="selectedProvider === 'openaiCompat'">
       <BaseInput v-model="openaiCompatBaseUrl">
         <template #label>Base URL</template>
@@ -122,6 +138,7 @@ export default {
       openaiApiKey: config["providers.openai.apiKey"],
       anthropicApiKey: config["providers.anthropic.apiKey"],
       googleApiKey: config["providers.google.apiKey"],
+      deepseekApiKey: config["providers.deepseek.apiKey"],
       ollamaBaseUrl: config.providers_ollama_baseUrl,
       ollamaHeaders: config.providers_ollama_headers,
       openaiCompatBaseUrl: config.providers_openaiCompat_baseUrl,
@@ -153,6 +170,10 @@ export default {
     },
     googleApiKey() {
       this.configure("providers.google.apiKey", this.googleApiKey);
+      this.$emit("change");
+    },
+    deepseekApiKey() {
+      this.configure("providers.deepseek.apiKey", this.deepseekApiKey);
       this.$emit("change");
     },
     ollamaBaseUrl() {

--- a/src/composables/ai.ts
+++ b/src/composables/ai.ts
@@ -377,7 +377,7 @@ class AIShellChat {
     }
     const model = this.getModelOrThrow();
     let prompt =
-      "Name this conversation in less than 30 characters or 6 words.\n```";
+      "Name this conversation in less than 30 characters or 6 words. Return JSON only.\n```";
     this.messages.value.forEach((m) => {
       m.parts.forEach((p) => {
         if (p.type === "text") {

--- a/src/config.ts
+++ b/src/config.ts
@@ -241,6 +241,25 @@ export const providerConfigs = {
     ],
     supportsRuntimeModels: false,
   },
+  deepseek: {
+    displayName: "DeepSeek",
+    /** @link https://api-docs.deepseek.com/api/list-models */
+    models: [
+      {
+        id: "deepseek-v4-flash",
+        displayName: "deepseek-v4-flash",
+        contextWindow: 1_000_000,
+        temperature: defaultTemperature,
+      },
+      {
+        id: "deepseek-v4-pro",
+        displayName: "deepseek-v4-pro",
+        contextWindow: 1_000_000,
+        temperature: defaultTemperature,
+      },
+    ],
+    supportsRuntimeModels: false,
+  },
   openaiCompat: {
     displayName: "OpenAI-Compatible",
     models: [],

--- a/src/providers/DeepSeekProvider.ts
+++ b/src/providers/DeepSeekProvider.ts
@@ -1,0 +1,25 @@
+import type { AvailableProviders, ModelInfo } from "@/config";
+import { providerConfigs } from "@/config";
+import { BaseProvider } from "@/providers/BaseProvider";
+import { createDeepSeek } from "@ai-sdk/deepseek";
+
+export class DeepSeekProvider extends BaseProvider {
+  constructor(private options: { apiKey: string }) {
+    super();
+  }
+
+  get providerId(): AvailableProviders {
+    return "deepseek";
+  }
+
+  getModel(id: string) {
+    return createDeepSeek({
+      apiKey: this.options.apiKey,
+    }).languageModel(id);
+  }
+
+  async listModels(): Promise<ModelInfo[]> {
+    // @ts-expect-error
+    return providerConfigs.deepseek.models;
+  }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,5 +1,6 @@
 import type { AvailableProviders } from "@/config";
 import { AnthropicProvider } from "@/providers/AnthropicProvider";
+import { DeepSeekProvider } from "@/providers/DeepSeekProvider";
 import { OpenAIProvider } from "@/providers/OpenAIProvider";
 import { OpenAICompatibleProvider } from "@/providers/OpenAICompatibleProvider";
 import { GoogleProvider } from "@/providers/GoogleProvider";
@@ -23,6 +24,10 @@ export function createProvider(id: AvailableProviders)  {
     case "google":
       return new GoogleProvider({
         apiKey: configuration["providers.google.apiKey"],
+      });
+    case "deepseek":
+      return new DeepSeekProvider({
+        apiKey: configuration["providers.deepseek.apiKey"],
       });
     case "openaiCompat":
       if (_.isEmpty(configuration.providers_openaiCompat_baseUrl)) {
@@ -50,4 +55,3 @@ export function createProvider(id: AvailableProviders)  {
       throw new Error(`Provider ${id} does not exist.`);
   }
 }
-

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -98,6 +98,19 @@ export const useChatStore = defineStore("chat", {
           !config.disabledModels.some(
             (disabled) =>
               m.id === disabled.modelId && disabled.providerId === "google",
+        ),
+        removable: false,
+      }));
+      const deepseekModels = providerConfigs.deepseek.models.map((m) => ({
+        ...m,
+        provider: "deepseek" as const,
+        providerDisplayName: providerConfigs.deepseek.displayName,
+        available: !!config["providers.deepseek.apiKey"],
+        enabled:
+          !!config["providers.deepseek.apiKey"] &&
+          !config.disabledModels.some(
+            (disabled) =>
+              m.id === disabled.modelId && disabled.providerId === "deepseek",
           ),
         removable: false,
       }));
@@ -131,6 +144,7 @@ export const useChatStore = defineStore("chat", {
         ...openaiModels,
         ...anthropicModels,
         ...googleModels,
+        ...deepseekModels,
         ...userDefinedModels,
         ...mockModels,
       ];

--- a/src/stores/configuration.ts
+++ b/src/stores/configuration.ts
@@ -58,6 +58,7 @@ type EncryptedConfigurable = {
   "providers.openai.apiKey": string;
   "providers.anthropic.apiKey": string;
   "providers.google.apiKey": string;
+  "providers.deepseek.apiKey": string;
   providers_openaiCompat_apiKey: string;
 };
 
@@ -69,6 +70,7 @@ const encryptedConfigKeys: (keyof EncryptedConfigurable)[] = [
   "providers.openai.apiKey",
   "providers.anthropic.apiKey",
   "providers.google.apiKey",
+  "providers.deepseek.apiKey",
   "providers_openaiCompat_apiKey",
 ];
 
@@ -83,6 +85,7 @@ const defaultConfiguration: ConfigurationState = {
   "providers.openai.apiKey": "",
   "providers.anthropic.apiKey": "",
   "providers.google.apiKey": "",
+  "providers.deepseek.apiKey": "",
   providers_openaiCompat_baseUrl: "",
   providers_openaiCompat_apiKey: "",
   providers_openaiCompat_headers: "",
@@ -91,6 +94,7 @@ const defaultConfiguration: ConfigurationState = {
   providers_openai_models: [],
   providers_anthropic_models: [],
   providers_google_models: [],
+  providers_deepseek_models: [],
   providers_openaiCompat_models: [],
   providers_ollama_models: [],
   providers_mock_models: [],

--- a/tests/providers/DeepSeekProvider.spec.ts
+++ b/tests/providers/DeepSeekProvider.spec.ts
@@ -1,0 +1,26 @@
+import { providerConfigs } from "../../src/config";
+import { DeepSeekProvider } from "../../src/providers/DeepSeekProvider";
+import { describe, expect, it } from "vitest";
+
+describe("DeepSeekProvider", () => {
+  it("creates DeepSeek language models through the AI SDK provider", () => {
+    const provider = new DeepSeekProvider({
+      apiKey: "test-key",
+    });
+
+    const model = provider.getModel("deepseek-v4-flash");
+
+    expect(model.provider).toBe("deepseek.chat");
+    expect(model.modelId).toBe("deepseek-v4-flash");
+  });
+
+  it("lists the configured DeepSeek models", async () => {
+    const provider = new DeepSeekProvider({
+      apiKey: "test-key",
+    });
+
+    await expect(provider.listModels()).resolves.toEqual(
+      providerConfigs.deepseek.models,
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,14 @@
     "@ai-sdk/provider" "3.0.2"
     "@ai-sdk/provider-utils" "4.0.4"
 
+"@ai-sdk/deepseek@^2.0.35":
+  version "2.0.35"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/deepseek/-/deepseek-2.0.35.tgz#3644e0c13d9756328d658497844d4a73a1c30629"
+  integrity sha512-9DhYurbAvcurOEGN6u2myYDybrrzGfcrkG8hwmFjwTrePW6KCMggm0YxP7e8RkLYcQKqCEMgFlyEB4BM6EmiKg==
+  dependencies:
+    "@ai-sdk/provider" "3.0.10"
+    "@ai-sdk/provider-utils" "4.0.27"
+
 "@ai-sdk/gateway@3.0.11":
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/@ai-sdk/gateway/-/gateway-3.0.11.tgz#e34dd3e239f97b4ee0965407c3792eb06b9cbf2b"
@@ -43,6 +51,15 @@
     "@ai-sdk/provider" "3.0.2"
     "@ai-sdk/provider-utils" "4.0.4"
 
+"@ai-sdk/provider-utils@4.0.27":
+  version "4.0.27"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz#d2183685768626bcf1c968b7d73ea2b974da59b9"
+  integrity sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==
+  dependencies:
+    "@ai-sdk/provider" "3.0.10"
+    "@standard-schema/spec" "^1.1.0"
+    eventsource-parser "^3.0.8"
+
 "@ai-sdk/provider-utils@4.0.4":
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-4.0.4.tgz#b2f5af446f152be64124725677a900be615c8766"
@@ -65,6 +82,13 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-2.0.0.tgz#b853c739d523b33675bc74b6c506b2c690bc602b"
   integrity sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==
+  dependencies:
+    json-schema "^0.4.0"
+
+"@ai-sdk/provider@3.0.10":
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-3.0.10.tgz#abfb6776f699951f9b8ac20cf1d42a3fc7d79752"
+  integrity sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==
   dependencies:
     json-schema "^0.4.0"
 
@@ -1926,6 +1950,11 @@ eventsource-parser@^3.0.5, eventsource-parser@^3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.6.tgz#292e165e34cacbc936c3c92719ef326d4aeb4e90"
   integrity sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==
+
+eventsource-parser@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.8.tgz#1c792503e4080455d00701bb1f7a1d60734d0e58"
+  integrity sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==
 
 expect-type@^1.2.1:
   version "1.2.2"


### PR DESCRIPTION
Follow-up to maintainer feedback on #94 to use the official AI SDK DeepSeek provider instead of custom OpenAI-compatible reasoning-content handling.

Summary:
- Adds DeepSeek as an official provider using @ai-sdk/deepseek.
- Keeps DeepSeek configuration aligned with OpenAI/Google/Anthropic: API key only.
- Adds current DeepSeek V4 model IDs to the static model config.
- Keeps OpenAI-compatible provider behavior generic.

Verification:
- corepack yarn test:run
- corepack yarn build