### PR TITLE
Add Z.AI GLM provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "vitest-browser-vue": "^1.1.0",
     "vue": "^3.4.21",
     "vue-tsc": "^3.1.0",
+    "zhipu-ai-provider": "^0.3.1",
     "zod": "^4.1.8"
   }
 }

--- a/src/components/ApiKeyForm.vue
+++ b/src/components/ApiKeyForm.vue
@@ -67,6 +67,22 @@
         </ExternalLink>
       </template>
     </BaseInput>
+    <BaseInput
+      v-if="!dropdownBased || selectedProvider === 'zai'"
+      type="password"
+      placeholder="sk-..."
+      v-model="zaiApiKey"
+    >
+      <template #label>
+        {{ dropdownBased ? "API Key" : providerConfigs["zai"].displayName }}
+      </template>
+      <template #helper>
+        Get your
+        <ExternalLink href="https://z.ai/manage-apikey/apikey-list">
+          API Key here.
+        </ExternalLink>
+      </template>
+    </BaseInput>
     <template v-if="selectedProvider === 'openaiCompat'">
       <BaseInput v-model="openaiCompatBaseUrl">
         <template #label>Base URL</template>
@@ -122,6 +138,7 @@ export default {
       openaiApiKey: config["providers.openai.apiKey"],
       anthropicApiKey: config["providers.anthropic.apiKey"],
       googleApiKey: config["providers.google.apiKey"],
+      zaiApiKey: config["providers.zai.apiKey"],
       ollamaBaseUrl: config.providers_ollama_baseUrl,
       ollamaHeaders: config.providers_ollama_headers,
       openaiCompatBaseUrl: config.providers_openaiCompat_baseUrl,
@@ -153,6 +170,10 @@ export default {
     },
     googleApiKey() {
       this.configure("providers.google.apiKey", this.googleApiKey);
+      this.$emit("change");
+    },
+    zaiApiKey() {
+      this.configure("providers.zai.apiKey", this.zaiApiKey);
       this.$emit("change");
     },
     ollamaBaseUrl() {

--- a/src/config.ts
+++ b/src/config.ts
@@ -126,6 +126,55 @@ export const providerConfigs = {
     ],
     supportsRuntimeModels: false,
   },
+  zai: {
+    displayName: "Z.AI (GLM)",
+    /** @link https://docs.z.ai/devpack/overview */
+    models: [
+      {
+        id: "glm-5.1",
+        displayName: "glm-5.1",
+        contextWindow: 200_000,
+        temperature: defaultTemperature,
+      },
+      {
+        id: "glm-5",
+        displayName: "glm-5",
+        contextWindow: 200_000,
+        temperature: defaultTemperature,
+      },
+      {
+        id: "glm-5-turbo",
+        displayName: "glm-5-turbo",
+        contextWindow: 200_000,
+        temperature: defaultTemperature,
+      },
+      {
+        id: "glm-4.7",
+        displayName: "glm-4.7",
+        contextWindow: 200_000,
+        temperature: defaultTemperature,
+      },
+      {
+        id: "glm-4.7-flashx",
+        displayName: "glm-4.7-flashx",
+        contextWindow: 200_000,
+        temperature: defaultTemperature,
+      },
+      {
+        id: "glm-4.7-flash",
+        displayName: "glm-4.7-flash",
+        contextWindow: 200_000,
+        temperature: defaultTemperature,
+      },
+      {
+        id: "glm-4.5-air",
+        displayName: "glm-4.5-air",
+        contextWindow: 128_000,
+        temperature: defaultTemperature,
+      },
+    ],
+    supportsRuntimeModels: false,
+  },
   openai: {
     displayName: "OpenAI",
     /** @link https://platform.openai.com/docs/models */

--- a/src/providers/ZaiProvider.ts
+++ b/src/providers/ZaiProvider.ts
@@ -1,0 +1,28 @@
+import type { AvailableProviders, ModelInfo } from "@/config";
+import { providerConfigs } from "@/config";
+import { BaseProvider } from "@/providers/BaseProvider";
+import { createZhipu } from "zhipu-ai-provider";
+
+const ZAI_BASE_URL = "https://api.z.ai/api/paas/v4";
+
+export class ZaiProvider extends BaseProvider {
+  constructor(private options: { apiKey: string }) {
+    super();
+  }
+
+  get providerId(): AvailableProviders {
+    return "zai";
+  }
+
+  getModel(id: string) {
+    return createZhipu({
+      baseURL: ZAI_BASE_URL,
+      apiKey: this.options.apiKey,
+    }).languageModel(id);
+  }
+
+  async listModels(): Promise<ModelInfo[]> {
+    // @ts-expect-error
+    return providerConfigs.zai.models;
+  }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -3,6 +3,7 @@ import { AnthropicProvider } from "@/providers/AnthropicProvider";
 import { OpenAIProvider } from "@/providers/OpenAIProvider";
 import { OpenAICompatibleProvider } from "@/providers/OpenAICompatibleProvider";
 import { GoogleProvider } from "@/providers/GoogleProvider";
+import { ZaiProvider } from "@/providers/ZaiProvider";
 import { useConfigurationStore } from "@/stores/configuration";
 import { OllamaProvider } from "./OllamaProvider";
 import { MockProvider } from "@/providers/MockProvider";
@@ -23,6 +24,10 @@ export function createProvider(id: AvailableProviders)  {
     case "google":
       return new GoogleProvider({
         apiKey: configuration["providers.google.apiKey"],
+      });
+    case "zai":
+      return new ZaiProvider({
+        apiKey: configuration["providers.zai.apiKey"],
       });
     case "openaiCompat":
       if (_.isEmpty(configuration.providers_openaiCompat_baseUrl)) {
@@ -50,4 +55,3 @@ export function createProvider(id: AvailableProviders)  {
       throw new Error(`Provider ${id} does not exist.`);
   }
 }
-

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -101,6 +101,19 @@ export const useChatStore = defineStore("chat", {
           ),
         removable: false,
       }));
+      const zaiModels = providerConfigs.zai.models.map((m) => ({
+        ...m,
+        provider: "zai" as const,
+        providerDisplayName: providerConfigs.zai.displayName,
+        available: !!config["providers.zai.apiKey"],
+        enabled:
+          !!config["providers.zai.apiKey"] &&
+          !config.disabledModels.some(
+            (disabled) =>
+              m.id === disabled.modelId && disabled.providerId === "zai",
+          ),
+        removable: false,
+      }));
       const userDefinedModels = config.models.map((m) => ({
         ...m,
         provider: m.providerId,
@@ -131,6 +144,7 @@ export const useChatStore = defineStore("chat", {
         ...openaiModels,
         ...anthropicModels,
         ...googleModels,
+        ...zaiModels,
         ...userDefinedModels,
         ...mockModels,
       ];

--- a/src/stores/configuration.ts
+++ b/src/stores/configuration.ts
@@ -58,6 +58,7 @@ type EncryptedConfigurable = {
   "providers.openai.apiKey": string;
   "providers.anthropic.apiKey": string;
   "providers.google.apiKey": string;
+  "providers.zai.apiKey": string;
   providers_openaiCompat_apiKey: string;
 };
 
@@ -69,6 +70,7 @@ const encryptedConfigKeys: (keyof EncryptedConfigurable)[] = [
   "providers.openai.apiKey",
   "providers.anthropic.apiKey",
   "providers.google.apiKey",
+  "providers.zai.apiKey",
   "providers_openaiCompat_apiKey",
 ];
 
@@ -83,6 +85,7 @@ const defaultConfiguration: ConfigurationState = {
   "providers.openai.apiKey": "",
   "providers.anthropic.apiKey": "",
   "providers.google.apiKey": "",
+  "providers.zai.apiKey": "",
   providers_openaiCompat_baseUrl: "",
   providers_openaiCompat_apiKey: "",
   providers_openaiCompat_headers: "",
@@ -91,6 +94,7 @@ const defaultConfiguration: ConfigurationState = {
   providers_openai_models: [],
   providers_anthropic_models: [],
   providers_google_models: [],
+  providers_zai_models: [],
   providers_openaiCompat_models: [],
   providers_ollama_models: [],
   providers_mock_models: [],

--- a/tests/providers/ZaiProvider.spec.ts
+++ b/tests/providers/ZaiProvider.spec.ts
@@ -1,0 +1,26 @@
+import { providerConfigs } from "../../src/config";
+import { ZaiProvider } from "../../src/providers/ZaiProvider";
+import { describe, expect, it } from "vitest";
+
+describe("ZaiProvider", () => {
+  it("creates Z.AI language models through the AI SDK provider", () => {
+    const provider = new ZaiProvider({
+      apiKey: "test-key",
+    });
+
+    const model = provider.getModel("glm-5.1");
+
+    expect(model.provider).toBe("zhipu.chat");
+    expect(model.modelId).toBe("glm-5.1");
+  });
+
+  it("lists the configured Z.AI GLM models", async () => {
+    const provider = new ZaiProvider({
+      apiKey: "test-key",
+    });
+
+    await expect(provider.listModels()).resolves.toEqual(
+      providerConfigs.zai.models,
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,10 +61,26 @@
     "@standard-schema/spec" "^1.0.0"
     eventsource-parser "^3.0.5"
 
+"@ai-sdk/provider-utils@^4.0.6":
+  version "4.0.27"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz#d2183685768626bcf1c968b7d73ea2b974da59b9"
+  integrity sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==
+  dependencies:
+    "@ai-sdk/provider" "3.0.10"
+    "@standard-schema/spec" "^1.1.0"
+    eventsource-parser "^3.0.8"
+
 "@ai-sdk/provider@2.0.0", "@ai-sdk/provider@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-2.0.0.tgz#b853c739d523b33675bc74b6c506b2c690bc602b"
   integrity sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==
+  dependencies:
+    json-schema "^0.4.0"
+
+"@ai-sdk/provider@3.0.10", "@ai-sdk/provider@^3.0.3":
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-3.0.10.tgz#abfb6776f699951f9b8ac20cf1d42a3fc7d79752"
+  integrity sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==
   dependencies:
     json-schema "^0.4.0"
 
@@ -1927,6 +1943,11 @@ eventsource-parser@^3.0.5, eventsource-parser@^3.0.6:
   resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.6.tgz#292e165e34cacbc936c3c92719ef326d4aeb4e90"
   integrity sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==
 
+eventsource-parser@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.8.tgz#1c792503e4080455d00701bb1f7a1d60734d0e58"
+  integrity sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==
+
 expect-type@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.2.2.tgz#c030a329fb61184126c8447585bc75a7ec6fbff3"
@@ -2949,6 +2970,14 @@ yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+zhipu-ai-provider@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/zhipu-ai-provider/-/zhipu-ai-provider-0.3.1.tgz#b6c43fbfd9e04bd3f774b9f0c307e6a10f53e1d0"
+  integrity sha512-3BGtV1RVLXU9GXFN7QGsoNZLkpp2E4Grt9GRWNcvYOQdUF7hvgZ59JxA4zys7j0gWuEq6Qvt9TlbzMAMwIyQyw==
+  dependencies:
+    "@ai-sdk/provider" "^3.0.3"
+    "@ai-sdk/provider-utils" "^4.0.6"
 
 zod@^4.1.8:
   version "4.1.8"


### PR DESCRIPTION
Summary:
- Adds Z.AI (GLM) as an API-key-only provider using the AI SDK community package zhipu-ai-provider.
- Adds current GLM models to the static provider config.
- Wires Z.AI into provider creation, encrypted API key storage, model availability, and onboarding/settings API-key form.

Verification:
- corepack yarn test:run
- corepack yarn build