### PR TITLE
Add Google models: gemini-3.7-flash

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -94,6 +94,12 @@ export const providerConfigs = {
     /** @link https://ai.google.dev/gemini-api/docs/models */
     models: [
       {
+        id: "gemini-3.7-flash",
+        displayName: "gemini-3.7-flash",
+        contextWindow: 1_048_576,
+        temperature: defaultTemperature,
+      },
+      {
         id: "gemini-3.6-flash",
         displayName: "gemini-3.6-flash",
         contextWindow: 1_048_576,


### PR DESCRIPTION
## Summary

Nightly model-sync run for 2026-08-15. Added one model that cleared the bar for inclusion; no other vendor changes qualified.

## Added

- **`gemini-3.7-flash`** (Google) — context window `1,048,576` tokens. Listed as "New Stable" / GA text model on the [Gemini API models page](https://ai.google.dev/gemini-api/docs/models) ("Gemini 3.7 Flash" → endpoint `gemini-3.7-flash"), confirmed on its own [detail page](https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash) (`Input token limit: 1,048,576`). Text/chat model, no gating. Inserted newest-first ahead of `gemini-3.6-flash`, using `defaultTemperature` (consistent with sibling Gemini 3.x entries).

## Considered and rejected

- **Anthropic** — every model ID on the [models overview page](https://platform.claude.com/docs/en/about-claude/models/overview) is already present in the config (`claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`, `claude-opus-4-8/4-7/4-6`, `claude-sonnet-4-6`, `claude-opus-4-5-20251101`, `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001`). `claude-mythos-5` / `claude-mythos-preview` are invitation-only (Project Glasswing) → gated, skipped per rule 4.
- **Google** — `gemini-3.1-flash-image`, `gemini-3.1-flash-lite-image`, `gemini-3-pro-image` (image gen), `gemini-3.5-live-translate-preview`, `gemini-3.1-flash-live-preview`, `gemini-3.1-flash-tts-preview`, `gemini-omni-flash` (audio/video/live), `gemini-embedding-2-preview`, `gemini-embedding-001` (embeddings) → wrong modality, skipped per rule 3. All other Gemini 3/2.5 text models already present.
- **OpenAI** — `gpt-5.6` is only an *alias* for the already-present `gpt-5.6-sol` (confirmed on [developers.openai.com/api/docs/models](https://developers.openai.com/api/docs/models): "GPT-5.6 Sol (Model ID: `gpt-5.6-sol`) with alias `gpt-5.6`") → duplicate, skipped per rule 7. `gpt-5.6-cyber`, `daybreak-red-latest`, `daybreak-blue-latest` → Daybreak-gated cyber models, skipped per rule 4. `gpt-image-2`, `gpt-realtime-*`, `gpt-4o-mini-tts`, `gpt-*-transcribe` → wrong modality, skipped per rule 3. All other GPT-5.x/4.1/o-series text models already present.

## Retirements checked (no action)

- Checked [Anthropic](https://platform.claude.com/docs/en/about-claude/model-deprecations), [Google](https://ai.google.dev/gemini-api/docs/deprecations), and [OpenAI](https://developers.openai.com/api/docs/deprecations) deprecation pages against every model currently in `src/config.ts`. No config model has a retirement date now in the past (2026-08-15):
  - `gemini-2.5-pro` carries a stale in-repo comment ("Retirement date: June 17, 2026") but the current Google deprecations page lists it as "No shutdown date announced" — leaving as-is since this isn't a new finding and touching it isn't a model-sync change.
  - OpenAI's `gpt-4.1-nano` retirement (Oct 23, 2026) and Anthropic's dated retirements don't match config IDs or aren't past yet.
  - Not touching any of this further — flagging only, per instructions that retirements alone are never a reason to open a PR.

## Verification

```
yarn install --frozen-lockfile   # pass
npx vue-tsc --noEmit -p tsconfig.app.json   # pass, no errors
npx vitest run   # pass — 4 files, 11 tests
```


---
_Generated by [Claude Code](https://claude.ai/code/session_017dGkn9GvkPqQkpRdtw3F9J)_