### PR TITLE
Add Google models: gemini-3.7-flash

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -94,6 +94,12 @@ export const providerConfigs = {
     /** @link https://ai.google.dev/gemini-api/docs/models */
     models: [
       {
+        id: "gemini-3.7-flash",
+        displayName: "gemini-3.7-flash",
+        contextWindow: 1_048_576,
+        temperature: defaultTemperature,
+      },
+      {
         id: "gemini-3.6-flash",
         displayName: "gemini-3.6-flash",
         contextWindow: 1_048_576,
@@ -412,22 +418,10 @@ export const disabledModelsByDefault: {
     // ===== Google =====
     // https://ai.google.dev/gemini-api/docs/deprecations
 
-    // Retirement date: June 17, 2026
+    // Legacy since June 17, 2025; no shutdown date announced as of this writing
     {
       providerId: "google" as const,
       modelId: "gemini-2.5-pro",
-    },
-
-    // Retirement date: June 1, 2026
-    {
-      providerId: "google" as const,
-      modelId: "gemini-2.0-flash",
-    },
-
-    // Retirement date: June 1, 2026
-    {
-      providerId: "google" as const,
-      modelId: "gemini-2.0-flash-lite",
     },
 
     // ===== OpenAI =====


### PR DESCRIPTION
## Summary

Nightly model-sync run for 2026-08-16.

### Added

- **`gemini-3.7-flash`** (Google) — GA text/chat model, input token limit **1,048,576**, output token limit 65,536. Confirmed on:
  - Model list: https://ai.google.dev/gemini-api/docs/models (listed under "Gemini 3 — Stable")
  - Model detail page: https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash (exact ID, token limits, GA status)

### Removed (retirement cleanup, bundled with the above per the runbook)

- Orphaned `disabledModelsByDefault` entries for `gemini-2.0-flash` and `gemini-2.0-flash-lite`. Both models were already absent from the `google.models` array (removed in a prior change), yet still referenced in `disabledModelsByDefault`. Per https://ai.google.dev/gemini-api/docs/deprecations both retired **June 1, 2026**, which has passed. Since they were not selectable to begin with, this is dead-code cleanup, not a behavior change.
- Left `gemini-2.5-pro`'s `disabledModelsByDefault` entry in place — Google's deprecation page shows it as "Legacy since June 17, 2025" with **no shutdown date announced**, so it stays available (disabled by default) rather than being retired.

## Considered and rejected

**Anthropic** (`platform.claude.com/docs/en/about-claude/models/overview.md`) — no gaps. All GA models on the page (`claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`, `claude-haiku-4-5-20251001`, and the "Legacy models" table) are already in config. `claude-mythos-5` / `claude-mythos-preview` are Project Glasswing invitation-only — skipped per the gated-access rule.

**Google** (`ai.google.dev/gemini-api/docs/models`) — besides `gemini-3.7-flash`, rejected:
- `gemini-3.1-flash-image`, `gemini-3.1-flash-lite-image`, `gemini-3-pro-image`, `gemini-2.5-flash-image` — image generation models, wrong modality.
- `gemini-omni-flash`, `gemini-3.5-live-translate-preview`, `gemini-3.1-flash-live-preview`, `gemini-3.1-flash-tts-preview`, `gemini-2.5-flash-native-audio-preview-12-2025`, `gemini-2.5-flash-preview-tts`, `gemini-2.5-pro-preview-tts` — live/audio/TTS models, wrong modality.
- `veo-3.1-*`, `lyria-*` — video/music generation, wrong modality.
- `gemini-embedding-*` — embedding model, wrong modality.
- `gemini-robotics-er-*`, `gemini-2.5-computer-use-preview-10-2025` — specialized/robotics, not a general chat model; skipped.
- `deep-research-preview-04-2026`, `deep-research-max-preview-04-2026`, `antigravity-preview-05-2026` — not confirmed as standard chat-completion models on the main models table; skipped.

**OpenAI** (`developers.openai.com/api/docs/models`) — no gaps. `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` are already in config. Rejected:
- `gpt-5.6-cyber`, `daybreak-red-latest`, `daybreak-blue-latest` — Daybreak-gated cyber models, explicitly excluded by the runbook.
- `gpt-image-2`, `gpt-realtime-*`, `gpt-4o-mini-tts`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-realtime-whisper`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe` — image/realtime/audio/transcription models, wrong modality.

## Deprecation check (no other action needed)

- OpenAI: `gpt-4.1-nano`, `o3-mini`, `o4-mini` are slated for retirement Oct 23, 2026 — still in the future, no action yet.
- OpenAI: `gpt-5-pro-2025-10-06` slated for Dec 11, 2026 — future, no action yet.
- Anthropic: none of the config's active models appear on the retired list.

## Verification

```
yarn install --frozen-lockfile   # ok
npx vue-tsc --noEmit -p tsconfig.app.json   # ok, no errors
npx vitest run   # 4 files, 11 tests, all passed
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QU61bQj1mX1AhFPkr29Hdu)_