### PR TITLE
Add Google models: gemini-3.7-flash

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -94,6 +94,12 @@ export const providerConfigs = {
     /** @link https://ai.google.dev/gemini-api/docs/models */
     models: [
       {
+        id: "gemini-3.7-flash",
+        displayName: "gemini-3.7-flash",
+        contextWindow: 1_048_576,
+        temperature: defaultTemperature,
+      },
+      {
         id: "gemini-3.6-flash",
         displayName: "gemini-3.6-flash",
         contextWindow: 1_048_576,
@@ -416,18 +422,6 @@ export const disabledModelsByDefault: {
     {
       providerId: "google" as const,
       modelId: "gemini-2.5-pro",
-    },
-
-    // Retirement date: June 1, 2026
-    {
-      providerId: "google" as const,
-      modelId: "gemini-2.0-flash",
-    },
-
-    // Retirement date: June 1, 2026
-    {
-      providerId: "google" as const,
-      modelId: "gemini-2.0-flash-lite",
     },
 
     // ===== OpenAI =====


### PR DESCRIPTION
## Summary

Nightly model-sync run for 2026-08-18.

### Added

- **`gemini-3.7-flash`** (Google) — context window **1,048,576** input tokens (65,536 output). Confirmed on the [models overview page](https://ai.google.dev/gemini-api/docs/models) (listed in the "All Gemini 3 models" table, GA/stable, no shutdown announced per the [deprecations page](https://ai.google.dev/gemini-api/docs/deprecations)) and on its [own detail page](https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash), which shows `Model code: gemini-3.7-flash`, supported inputs Text/Image/Video/Audio/PDF, output Text, and the token-limit table (Input token limit: 1,048,576 / Output token limit: 65,536). Inserted newest-first, `temperature: defaultTemperature` (matches sibling Gemini 3.x flash entries; Google does not reject non-default sampling params for this family).

### Retirements (secondary — bundled since a new model already warranted a PR)

- Removed the `disabledModelsByDefault` entries for **`gemini-2.0-flash`** and **`gemini-2.0-flash-lite`**. Per the [Gemini deprecations page](https://ai.google.dev/gemini-api/docs/deprecations), both retired (shutdown) June 1, 2026, which is now in the past. Neither was present in the `models` array already, so these were dangling entries; removed for cleanup, not a behavior change for any user (they couldn't be selected anyway).
- Left the `gemini-2.5-pro` `disabledModelsByDefault` entry untouched — the in-repo comment says "Retirement date: June 17, 2026" but the live deprecations page currently shows **no shutdown date announced** for `gemini-2.5-pro`, so it does not meet the "retirement date now in the past" bar. Flagging the stale comment for a human to reconcile, but not touching it.

### Considered and rejected

**Anthropic** — no new models. All models on the [overview page](https://platform.claude.com/docs/en/about-claude/models/overview.md) (`claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`, `claude-opus-4-8`, `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-opus-4-6`, `claude-opus-4-5-20251101`, `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001`) are already present. `claude-mythos-5` / `claude-mythos-preview` are Project Glasswing invitation-only (gated) → skipped per rule. Checked [model-deprecations.md](https://platform.claude.com/docs/en/about-claude/model-deprecations.md) — no model currently in the config has a retirement date in the past.

**Google** — other candidates rejected:
  - `gemini-3.1-flash-image`, `gemini-3.1-flash-lite-image`, `gemini-3-pro-image`, `gemini-2.5-flash-image`, `imagen-4.0-generate` — image generation, wrong modality.
  - `gemini-3.5-live-translate-preview`, `gemini-3.1-flash-live-preview`, `gemini-3.1-flash-tts-preview`, `gemini-omni-flash`, `gemini-2.5-flash-native-audio-preview-12-2025`, `gemini-2.5-flash-preview-tts`, `gemini-2.5-pro-preview-tts` — audio/video/TTS, wrong modality.
  - `veo-3.1-generate-preview`, `veo-3.1-lite-generate-preview`, `lyria-3-pro-preview`, `lyria-3-clip-preview`, `lyria-realtime-exp` — video/music generation, wrong modality.
  - `gemini-embedding-2-preview`, `gemini-embedding-001` — embeddings, wrong modality.
  - `gemini-robotics-er-2-preview`, `gemini-robotics-er-1.6-preview` — robotics/vision-understanding, not a general chat model.
  - `gemini-2.5-computer-use-preview-10-2025`, `deep-research-preview-04-2026`, `deep-research-max-preview-04-2026`, `antigravity-preview-05-2026` — specialized agentic tool models, not general chat.

**OpenAI** — no new models. [Models page](https://developers.openai.com/api/docs/models) shows `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` as the frontier text models — all already present in the config. Other candidates rejected:
  - `gpt-5.6-cyber`, `daybreak-red-latest`, `daybreak-blue-latest` — Daybreak-gated cybersecurity models, explicitly excluded per instructions.
  - `gpt-image-2` — image generation, wrong modality.
  - `gpt-realtime-2.1`, `gpt-realtime-2.1-mini`, `gpt-realtime-2`, `gpt-realtime-translate`, `gpt-realtime-1.5`, `gpt-realtime-mini`, `gpt-4o-mini-tts`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-realtime-whisper`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe` — realtime/audio/transcription, wrong modality.
  - Checked [deprecations page](https://developers.openai.com/api/docs/deprecations) — the earliest upcoming deprecation date (`gpt-realtime` family etc.) is January 20, 2027; none affecting models currently in the config have a retirement date in the past yet (earliest is August 26, 2026, still in the future).

## Verification

```
yarn install --frozen-lockfile   # OK
npx vue-tsc --noEmit -p tsconfig.app.json   # OK, no errors
npx vitest run   # 4 files, 11 tests, all passed
```

## Run summary

- Anthropic: fetched successfully (overview + deprecations). 0 candidates cleared the bar.
- Google: fetched successfully (models + deprecations, plus the `gemini-3.7-flash` detail page for context-window confirmation). 1 candidate (`gemini-3.7-flash`) cleared the bar; ~20 rejected for modality/gating.
- OpenAI: fetched successfully (models + deprecations). 0 candidates cleared the bar; several rejected for gating/modality.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XApHbHrZAMQKM8K2b1RPVU)_